### PR TITLE
Change aws role to input variable.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'The account ID of the container registry.'
     required: true
 
+  aws_role_to_assume:
+    description: 'Name of the role to assume.'
+    required: true
+
   aws_region:
     description: 'The region the container registry is hosted in.'
     required: true
@@ -35,7 +39,7 @@ runs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@master
       with:
-        role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/github-actions-${{ github.event.repository.name }}
+        role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
 
     - name: Login to Amazon ECR

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   aws_role_to_assume:
     description: 'Name of the role to assume.'
     required: true
-
+    default: 'github-actions-${{ github.event.repository.name }}'
   aws_region:
     description: 'The region the container registry is hosted in.'
     required: true

--- a/example.yml
+++ b/example.yml
@@ -28,3 +28,4 @@ jobs:
         with:
           aws_account_id: REGISTRY_ACCOUNT
           aws_region: REGISTRY_REGION
+          aws_role_to_assume: 'github-actions-${{ github.event.repository.name }}'


### PR DESCRIPTION
With this, the naming pattern of the aws role wont be forced. 
