### PR TITLE
Allow custom ECR repo name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,6 @@ inputs:
     required: false
     default: ${{ github.event.repository.name }}
 
-
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,12 @@ inputs:
     description: 'A list of secrets to be passed through to the docker build, if needed (eg `key=string`).'
     required: false
 
+  ecr_repo_name:
+    description: 'An ECR registry name , if not the name of the repository'
+    required: false
+    default: ${{ github.event.repository.name }}
+
+
 runs:
   using: "composite"
   steps:
@@ -67,7 +73,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_region }}.amazonaws.com/${{ github.event.repository.name }}
+        images: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_region }}.amazonaws.com/${{ inputs.ecr_repo_name }}
         tags: |
           type=schedule,pattern=latest
           type=semver,pattern={{version}}

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
 
   ecr_repo_name:
-    description: 'An ECR registry name , if not the name of the repository'
+    description: 'An ECR repository name. Defaults to the name of the Github repository.'
     required: false
     default: ${{ github.event.repository.name }}
 


### PR DESCRIPTION
I needed this for a case where the ECR repository name doesn't match the git repository name. I think this may be useful for others. 