### PR TITLE
bump the action versions to deal with the various github deprecations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Quick ECR Push'
 description: 'Push containers to ECR easily.'
 
 branding:
-  icon: 'arrow-up-right'  
+  icon: 'arrow-up-right'
   color: 'yellow'
 
 
@@ -53,13 +53,13 @@ runs:
   steps:
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_role_to_assume }}
         aws-region: ${{ inputs.aws_region }}
@@ -70,7 +70,7 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: ${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_region }}.amazonaws.com/${{ inputs.ecr_repo_name }}
         tags: |
@@ -81,7 +81,7 @@ runs:
           type=ref,event=branch
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}


### PR DESCRIPTION
Github is deprecating node12 ([link](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)) as well as the `set-output` and `save-state` commands ([link](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)). This PR updates all the actions used here to versions that don't throw deprecation warnings anymore.

I'm leaving this as a draft for now because `amazon-ecr-login` will possibly need to be updated once [this issue](https://github.com/aws-actions/amazon-ecr-login/issues/358) is resolved - assuming they do a major release, we'll then need to update that to the new version here as well. 

I've tested these new versions in other places where we use these actions without issue and haven't run into any issues. 